### PR TITLE
YAML: remove Brandon's markdown demo page from active links on website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,4 +66,5 @@ pages:
         - NekBone: case_studies/nek/index.md
         - MD: case_studies/md/index.md
 - Other Resources: resources.md
-- Demo: demo/demo.md
+# see Brandon's markdown demo page here:
+#- Demo: demo/demo.md


### PR DESCRIPTION
The page is still in the repository for convenient copy/paste access,
but won't be visible on the website.