### PR TITLE
Add mention and link to BSSw website.

### DIFF
--- a/docs/perfport/strategy.md
+++ b/docs/perfport/strategy.md
@@ -10,6 +10,8 @@ portabile and ultimately more productive by applying recommended software engine
 * Maintaining a rigorours test-suite and automated regression test framework on multiple platforms
 * Developing code in a modular way that abstracts performance-critical regions
 
+The [Better Scientific Software (BSSw)](https://bssw.io/) site is a valuable resource---a hub for sharing information and educating about best practices.
+
 ## Developing a Performance Portability Strategy 
 
 We noted in the introduction that the KNL and NVIDIA GPU architectures had a lot in common, including wide "vectors" or "warps," as well as multiple tiers of memory, including on-package memory. However, before diving into to any particular performance-portability programming model, it is important to develop a high-level strategy for how a given problem best maps to these similar architecture features. In exploring various approaches to performance portability, we have found that different strategies can exist for exploiting these similarities. 

--- a/docs/perfport/strategy.md
+++ b/docs/perfport/strategy.md
@@ -7,7 +7,7 @@ portabile and ultimately more productive by applying recommended software engine
 
 * Developing in a well-defined version-controlled environment
 * Documenting code so other developers can quickly join and contribute to a project
-* Maintaining a rigorours test-suite and automated regression test framework on multiple platforms
+* Maintaining a rigorous test-suite and automated regression test framework on multiple platforms
 * Developing code in a modular way that abstracts performance-critical regions
 
 The [Better Scientific Software (BSSw)](https://bssw.io/) site is a valuable resource---a hub for sharing information and educating about best practices.

--- a/docs/perfport/strategy.md
+++ b/docs/perfport/strategy.md
@@ -10,7 +10,7 @@ portabile and ultimately more productive by applying recommended software engine
 * Maintaining a rigorous test-suite and automated regression test framework on multiple platforms
 * Developing code in a modular way that abstracts performance-critical regions
 
-The [Better Scientific Software (BSSw)](https://bssw.io/) site is a valuable resource---a hub for sharing information and educating about best practices.
+The [Better Scientific Software (BSSw)](https://bssw.io/) site is a valuable resource&mdash;a hub for sharing information and educating about best practices.
 
 ## Developing a Performance Portability Strategy 
 


### PR DESCRIPTION
Add mention and link to BSSw website under Code Structure and Practices on the Strategy. This is  as discussed with Lois Curfman McInnes. (She put in some featured links to performanceportability.org on the BSSw site.)